### PR TITLE
Added a requirements.txt for the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `modules` folder contains all available modules for the bot. Each module mus
 At the moment the following functionalities are avaibalbe:
 * `help`: handles `!help` command for each other functionality
 * `random`: generate pseudo-random numbers in the form of pen&paper die throws
-* `testfunc`: debug and testing purpose only, showing debug output on console. Also works with multiple channels on multiple servers. To remove this from a running bot, delete the occurrences in lines 7, 13 and 16 in `ultrabot.py` 
+* `testfunc`: debug and testing purpose only, showing debug output on console. Also works with multiple channels on multiple servers. To remove this from a running bot, delete the occurrences in lines 7, 13 and 16 in `ultrabot.py`
 
 
 ## TODO
@@ -30,6 +30,13 @@ At the moment the following functionalities are avaibalbe:
 
 ## Dependencies
 
+* **Python3.4+**
 * [discord.py](https://github.com/Rapptz/discord.py) library
-* Python3.4+
 * `asyncio` library
+
+
+You can install the dependencies with pip doing
+
+```
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=0.16.12[voice]
+asyncio>=3.4.3


### PR DESCRIPTION
You can actually create a `requirements.txt` file that lists all the dependencies to install them with a single command. I did just that.

The dependencies can now be install with
```
pip install -r requirements.txt
```

or on systems that don't serve python3 as default (pretty much anything else than **Arch Linux**`
```
pip3 install -r requirements.txt
```

I added a note about it in the `README.md` and made the **Python 3.4** dependencies bold because this project uses code that requires Python 3 and a lot of systems are still using Python 2 by default. Of course I can change that if it bothers you.