### PR TITLE
Maximum number of parameters is for a plugin is checked by the bot itself

### DIFF
--- a/metamodule.py
+++ b/metamodule.py
@@ -21,3 +21,6 @@ class Meta(metaclass=ABCMeta):
     @abstractmethod
     async def help(self, message):
         pass
+
+    def get_max_parameters(self):
+        return None

--- a/ultrabot.py
+++ b/ultrabot.py
@@ -23,7 +23,7 @@ def load_token() -> str:
 def get_help_msg() -> str:
     commands = ", ".join([f"`!{task}`" for task in TASKS.keys()])
     return f"""Available commands: `!list`, {commands}
-    
+
     Use `!help <command>` for information about commands.
     """
 
@@ -94,7 +94,15 @@ def run_client():
 
         # command is in dict, forward command and parameters, as well as the entire message, to functionality object
         com = command.pop(0)
-        client.loop.create_task(TASKS[com].execute(command, message))
+        # check if the number of parameters exceed the ones allowed for the plugin
+        max_para = TASKS[com].get_max_number_of_parameters()
+        # if the number of parameters exceed the maximum give an error message and send the plugin's help message
+        if(max_para and len(command) > max_para):
+            await client.send_message(message.channel, f'Too many arguments for `!{com}`')
+            await TASKS[com].help(message)
+        # run the plugin
+        else:
+            client.loop.create_task(TASKS[com].execute(command, message))
 
     client.run(load_token())
 


### PR DESCRIPTION
I add a **non-abstract** method to the metamodule `Meta` baseclass called `get_max_parameters()`.
It returns the maximum allowed number of parameters for that plugin and by default `None`, which means there is no maximum.

The bot now checks if the number of parameters exceed the number of allowed ones and sends an error message, along with the plugins *help message*. 

Since this method is not abstract, plugins don't have to overwrite it, they only should if they want to limit their number of parameters. 

This gives 2 benefits:

* One redundant, mundane thing less to check on the plugin side
* Unified error message for every plugin, since it is defined in `ultrabot.py`

It will also not break already existing plugins.